### PR TITLE
Minor modifications to model CIP-50 correctly

### DIFF
--- a/batch-run.py
+++ b/batch-run.py
@@ -44,10 +44,12 @@ if __name__ == "__main__":
                              'the original cost value of the stakeholder. Default is 40%%.')
     parser.add_argument('--stake_distr_source', nargs="?", type=str, default='Pareto',
                         help='The distribution type to use for the initial allocation of stake to the agents.')
-    parser.add_argument('--reward_scheme', nargs="?", type=int, default=0, choices=range(4),
+    parser.add_argument('--reward_scheme', nargs="?", type=int, default=0, choices=range(5),
                         help='The reward scheme to use in the simulation. 0 for the original reward scheme of Cardano, '
                              '1 for a simplified version of it, 2 for a reward scheme with flat pledge benefit, 3 for '
                              'a reward scheme with curved pledge benefit (CIP-7) and 4 for the reward scheme of CIP-50.')
+    parser.add_argument('--L', nargs="*", type=int, default=1000,
+                        help='The L parameter for CIP50RSS (custom saturation threshold factor). Default is 1000.')
     parser.add_argument('--relative_utility_threshold', nargs="+", type=float, default=0,
                         help='The utility increase ratio under which moves are disregarded. Default is 0%%.')
     parser.add_argument('--absolute_utility_threshold', nargs="+", type=float, default=0,

--- a/logic/helper.py
+++ b/logic/helper.py
@@ -550,6 +550,8 @@ def add_script_arguments(parser):
                         help='The reward scheme to use in the simulation. 0 for the original reward scheme of Cardano, '
                              '1 for a simplified version of it, 2 for a reward scheme with flat pledge benefit, 3 for '
                              'a reward scheme with curved pledge benefit (CIP-7) and 4 for the reward scheme of CIP-50.')
+    parser.add_argument('--L', nargs="?", type=positive_int, default=1000,
+                        help='The L parameter for CIP50RSS (custom saturation threshold factor). Default is 1000.')
     parser.add_argument('--agent_profile_distr', nargs=len(PROFILE_MAPPING), type=non_negative_float, default=[1, 0, 0],
                         help='The weights for assigning different profiles to the agents. Default is [1, 0, 0], i.e. '
                              '100%% non-myopic agents.')

--- a/logic/sim.py
+++ b/logic/sim.py
@@ -23,7 +23,7 @@ class Simulation(Model):
             inactive_stake_fraction=0, inactive_stake_fraction_known=False, relative_utility_threshold=0,
             absolute_utility_threshold=0, seed=None, pareto_param=2.0, max_iterations=1000, cost_min=1e-5,
             cost_max=1e-4, extra_pool_cost_fraction=0.4, agent_activation_order="random",
-            iterations_after_convergence=10, reward_scheme=0, execution_id='', seq_id=-1, parent_dir='',
+            iterations_after_convergence=10, reward_scheme=0, L=1000, execution_id='', seq_id=-1, parent_dir='',
             metrics=None, generate_graphs=True, input_from_file=False
     ):
         if input_from_file:
@@ -70,7 +70,7 @@ class Simulation(Model):
         self.reward_scheme = rss.RSS_MAPPING[args['reward_scheme']](-1, -1)
 
         other_fields = [
-            'n', 'k', 'a0', 'relative_utility_threshold', 'absolute_utility_threshold', 'max_iterations',
+            'n', 'k', 'a0', 'L', 'relative_utility_threshold', 'absolute_utility_threshold', 'max_iterations',
             'extra_pool_cost_fraction', 'agent_activation_order', 'generate_graphs'
         ]
         multi_phase_params = {}

--- a/main.py
+++ b/main.py
@@ -31,6 +31,7 @@ def main():
         # total stake
         iterations_after_convergence=args.iterations_after_convergence,
         reward_scheme=args.reward_scheme,
+        L=args.L,
         execution_id=args.execution_id,
         # seq_id
         # parent_dir


### PR DESCRIPTION
## Summary
This pull request introduces support for the CIP-50 reward scheme in the simulation framework and adds the `--L` parameter to control the custom saturation threshold factor.

The implementation of CIP-50 is actually quite simple, despite the lengthy write-up in its original repository.  The existing Cardano rewards scheme remains intact, with only the addition of a secondary saturation threshold based on the L parameter.  The effect of the adjustable parameter L is to add Sybil resistance by making low pledge, high-stake pools less feasible.

## Changes
- Extend `--reward_scheme` choices to include index 4 (CIP-50) in `batch-run.py` and `logic/helper.py`.
- Add new CLI argument `--L` (default: 1000) in `batch-run.py`, `logic/helper.py`, `logic/sim.py`, and `main.py` to configure the CIP-50 saturation parameter.
- Implement `CIP50RSS` class in `logic/reward_schemes.py`:
  - Add `L` attribute in constructor.
  - Update `get_pool_saturation_threshold` to use `L * pledge` instead of `a0 * pledge`.
  - Refine `calculate_pool_reward` logic to incorporate a secondary threshold per CIP-50 specification.
- Update `Simulation` class to accept and propagate the `L` parameter.

## Motivation
CIP-50 proposes an alternative saturation mechanism for Cardano pool rewards. This PR enables experimentation with the CIP-50 reward scheme by exposing the necessary parameter and implementing the required logic.

## Impact
Backward compatible: existing simulations (reward_scheme 0-3) are unaffected. Users can now run simulations with `--reward_scheme 4` and customize the `L` parameter as needed.

## Testing
- Manual testing: `python batch-run.py --reward_scheme 4 --n=2000 --k 250 500 1000 2000 --a0 0.3 --L 1 10 100 1000 10000 --execution_id=CIP-50-Test`